### PR TITLE
Allow redirects to ALLOWED_HOSTS

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -71,6 +71,20 @@ app.config['SIMPLELOGIN_HOME_URL'] = '/en/'
 SimpleLogin(app)
 ```
 
+## Protection against open redirects
+
+Flask Simple Login doesn't allow redirects to external URLs, but it can be configured to do so:
+
+```py
+app.config["ALLOWED_HOSTS"] = ["myothersite.com"]
+```
+
+Then it is possible to redirect to an external URL in the `next=` parameter:
+
+```py
+url_for('simplelogin.login', next='http://myothersite.com/')
+```
+
 ## Encrypting passwords
 
 You can use the `from werkzeug.security import check_password_hash, generate_password_hash` utilities to encrypt passwords.

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -313,7 +313,10 @@ class SimpleLogin:
 
         host_url = urlparse(request.host_url)
         redirect_url = urlparse(urljoin(request.host_url, destiny))
-        if not host_url.netloc == redirect_url.netloc:
+        if (
+            not host_url.netloc == redirect_url.netloc
+            and redirect_url.netloc not in self.app.config.get("ALLOWED_HOSTS", [])
+        ):
             return abort(400, "Invalid next url, can only redirect to the same host")
 
         if is_logged_in():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -38,6 +38,16 @@ def test_negative_redirect_to_external_url(client):
     assert "Invalid next url" in str(response.data)
 
 
+def test_positive_redirect_to_allowed_host(app):
+    app.config["ALLOWED_HOSTS"] = ["myothersite.com"]
+    with app.test_client() as client:
+        response = client.get(
+            url_for("simplelogin.login", next="https://myothersite.com/page"),
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+
+
 # def test_is_logged_in(client):
 #     session.clear()
 #     session['csrf_token'] = '123456'


### PR DESCRIPTION
This follows a common pattern of having an ALLOWED_HOSTS config and is useful when website has multiple domains.