### PR TITLE
Add Logout Callback Functionality

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -90,3 +90,27 @@ url_for('simplelogin.login', next='http://myothersite.com/')
 You can use the `from werkzeug.security import check_password_hash, generate_password_hash` utilities to encrypt passwords.
 
 A working example is available in `manage.py` of [example app](https://github.com/flask-extensions/Flask-SimpleLogin/tree/main/example)
+
+## Registering Custom Logout Callback(s)
+
+You can define multiple custom logout callbacks to be executed after the user logs out using the `register_on_logout_callback` method:
+
+```python
+from flask import Flask
+from flask_simplelogin import SimpleLogin
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'something-secret'
+simple_login = SimpleLogin(app)
+
+def my_post_logout_callback():
+    print("User has logged out")
+
+def another_post_logout_callback():
+    print("Another action after logout")
+
+simple_login.register_on_logout_callback(my_post_logout_callback)
+simple_login.register_on_logout_callback(another_post_logout_callback)
+```
+
+The callbacks will be executed in the order they were registered.

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -357,7 +357,6 @@ class SimpleLogin:
         session.clear()
         self.flash("logout")
 
-        # call all registered callbacks
         for callback in self.on_logout_callbacks:
             callback()
 

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -196,6 +196,7 @@ class SimpleLogin:
         self.app = None
         self._login_checker = login_checker or default_login_checker
         self._login_form = login_form or LoginForm
+        self.on_logout_callbacks = []
         if app is not None:
             self.init_app(
                 app=app,
@@ -348,7 +349,16 @@ class SimpleLogin:
 
         return render_template("login.html", form=form, next=destiny), ret_code
 
+    def register_on_logout_callback(self, callback):
+        """Register a callback to be called on logout"""
+        self.on_logout_callbacks.append(callback)
+
     def logout(self):
         session.clear()
         self.flash("logout")
+
+        # call all registered callbacks
+        for callback in self.on_logout_callbacks:
+            callback()
+
         return redirect(self.config.get("home_url", "/"))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,5 @@
 from base64 import b64encode
-from unittest.mock import call
+from unittest.mock import call, Mock
 
 from flask import url_for
 
@@ -80,15 +80,8 @@ def test_is_logged_in_from_json_request(app, client):
 
 
 def test_logout(app, client, csrf_token_for):
-    callback_called = []
-
-    def callback1():
-        nonlocal callback_called
-        callback_called.append(True)
-
-    def callback2():
-        nonlocal callback_called
-        callback_called.append(True)
+    callback1 = Mock()
+    callback2 = Mock()
 
     simplelogin = app.extensions["simplelogin"]
     simplelogin.register_on_logout_callback(callback1)
@@ -108,7 +101,8 @@ def test_logout(app, client, csrf_token_for):
     client.get(url_for("simplelogin.logout"))
     assert not is_logged_in()
 
-    assert callback_called == [True, True]
+    callback1.assert_called_once()
+    callback2.assert_called_once()
 
 
 def test_flash(app, mocker):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -80,6 +80,20 @@ def test_is_logged_in_from_json_request(app, client):
 
 
 def test_logout(app, client, csrf_token_for):
+    callback_called = []
+
+    def callback1():
+        nonlocal callback_called
+        callback_called.append(True)
+
+    def callback2():
+        nonlocal callback_called
+        callback_called.append(True)
+
+    simplelogin = app.extensions["simplelogin"]
+    simplelogin.register_on_logout_callback(callback1)
+    simplelogin.register_on_logout_callback(callback2)
+
     client.get(url_for("simplelogin.login"))
     assert not is_logged_in()
     client.post(
@@ -93,6 +107,8 @@ def test_logout(app, client, csrf_token_for):
     assert is_logged_in()
     client.get(url_for("simplelogin.logout"))
     assert not is_logged_in()
+
+    assert callback_called == [True, True]
 
 
 def test_flash(app, mocker):


### PR DESCRIPTION
## Overview

This PR introduces the ability to register and execute **callback functions** upon user logout in the `SimpleLogin` class. This enhancement allows users to perform custom actions, such as logging events or clearing additional session data, immediately after a user logs out.

## Changes

- **Modified `logout` Method**:
   - The logout method now iterates over a list of registered callbacks and executes each one after clearing the session and flashing the logout message.

- **New Method `register_on_logout_callback`**:
    - Added a new method `register_on_logout_callback` to allow users to register their custom callback functions.

- **Updated Tests**:
    - Enhanced the existing logout test to verify that the registered callbacks are executed upon logout.

## Code Example

Here's how users can register their custom callbacks:

```py
def my_post_logout_callback():
    print("User has logged out")

def another_post_logout_callback():
    print("Another action after logout")

app = Flask(__name__)
simple_login = SimpleLogin(app)
simple_login.register_on_logout_callback(my_post_logout_callback)
simple_login.register_on_logout_callback(another_post_logout_callback)
```

## Testing

- **Manual Testing**:
    - Verified the functionality by running a local Flask application and observing the console output upon logout.

- **Automated Testing**:
    - Updated the test suite to include checks for the new callback functionality.
    - Ran the tests using `pytest` to ensure all tests pass successfully.

## Additional Notes

- Users can register **multiple callbacks**, and they will be executed in the order they were registered.

**This PR addresses issue #36** 